### PR TITLE
Documentation/update imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Collection of essential Svelte Composition Utilities
 
 ```svelte
 <script lang="ts">
-import { useCounter } from "$lib";
+import { useCounter } from "svelte-legos";
 
 const { counter, inc, dec, set, reset } = useCounter();
 </script>
@@ -30,7 +30,7 @@ const { counter, inc, dec, set, reset } = useCounter();
 
 ```svelte
 <script lang="ts">
-import { useWindowSize } from "$lib";
+import { useWindowSize } from "svelte-legos";
 
 const size = useWindowSize();
 </script>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
 	"name": "svelte-legos",
 	"version": "0.0.1",
 	"main": "./package/index.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/ankurrsinghal/svelte-legos.git"
+	},
+	"bugs": {
+		"url": "https://github.com/ankurrsinghal/svelte-legos/issues"
+	},
+	"homepage": "https://svelte-legos.singhalankur.com/",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package",

--- a/src/lib/hooks/useActiveElement/usage.txt
+++ b/src/lib/hooks/useActiveElement/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useActiveElement } from '$lib';
+import { useActiveElement } from 'svelte-legos';
 
 const activeElement = useActiveElement();
 

--- a/src/lib/hooks/useCounter/usage.txt
+++ b/src/lib/hooks/useCounter/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useCounter } from "$lib/hooks/useCounter";
+import { useCounter } from "svelte-legos";
 
 const { counter, inc, dec, set, reset } = useCounter();
 </script>

--- a/src/lib/hooks/useDocumentVisibility/usage.txt
+++ b/src/lib/hooks/useDocumentVisibility/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useElementSize } from "$lib/hooks/useElementSize";
+import { useElementSize } from "svelte-legos";
 
 const visibility = useElementSize();
 

--- a/src/lib/hooks/useElementSize/usage.txt
+++ b/src/lib/hooks/useElementSize/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useElementSize } from "$lib/hooks/useElementSize";
+import { useElementSize } from "svelte-legos";
 
 let ref: HTMLElement | null = null;
 

--- a/src/lib/hooks/useElementVisibility/usage.txt
+++ b/src/lib/hooks/useElementVisibility/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useElementVisibility } from "$lib/hooks/useElementVisibility";
+import { useElementVisibility } from "svelte-legos";
 
 let ref: HTMLElement | null = null;
 

--- a/src/lib/hooks/useInterval/usage.txt
+++ b/src/lib/hooks/useInterval/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useInterval } from "$lib";
+import { useInterval } from "svelte-legos";
 
 const counter = useInterval(200);
 

--- a/src/lib/hooks/useIntervalFn/usage.txt
+++ b/src/lib/hooks/useIntervalFn/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useIntervalFn } from "$lib/hooks/useIntervalFn";
+import { useIntervalFn } from "svelte-legos";
 
 const { pause, resume, isActive, changeIntervalTime } = useIntervalFn(() => {
   /* your function */

--- a/src/lib/hooks/useMouse/usage.txt
+++ b/src/lib/hooks/useMouse/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useMouse } from '$lib/hooks/useMouse';
+import { useMouse } from 'svelte-legos';
 
 const position = useMouse();
 

--- a/src/lib/hooks/useRafFn/usage.txt
+++ b/src/lib/hooks/useRafFn/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useRafFn } from "$lib";
+import { useRafFn } from "svelte-legos";
 
 let counter = 0;
 

--- a/src/lib/hooks/useResizeObserver/usage.txt
+++ b/src/lib/hooks/useResizeObserver/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useResizeObserver } from "$lib/hooks/useResizeObserver";
+import { useResizeObserver } from "svelte-legos";
 
 let ref: HTMLElement | null = null;
 

--- a/src/lib/hooks/useTimeout/usage.txt
+++ b/src/lib/hooks/useTimeout/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useTimeout } from '$lib/hooks/useTimeout';
+import { useTimeout } from 'svelte-legos';
 
 const ready = useTimeout(2000);
 

--- a/src/lib/hooks/useTimeoutFn/usage.txt
+++ b/src/lib/hooks/useTimeoutFn/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useTimeoutFn } from '$lib/hooks/useTimeoutFn';
+import { useTimeoutFn } from 'svelte-legos';
 
 const { isPending, start, stop } = useTimeoutFn(() => {
     /* ... */

--- a/src/lib/hooks/useToggle/usage.txt
+++ b/src/lib/hooks/useToggle/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useToggle } from "$lib/hooks/useToggle";
+import { useToggle } from "svelte-legos";
 
 const { toggle, on, off, set, value } = useToggle();
 

--- a/src/lib/hooks/useWindowFocus/usage.txt
+++ b/src/lib/hooks/useWindowFocus/usage.txt
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useWindowFocus } from '$lib/hooks/useWindowFocus';
+import { useWindowFocus } from 'svelte-legos';
 
 const isFocused = useWindowFocus();
 

--- a/src/lib/hooks/useWindowScroll/usage.txt
+++ b/src/lib/hooks/useWindowScroll/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { useWindowScroll } from 'svelte-use';
+import { useWindowScroll } from 'svelte-legos';
 
 const position = useWindowScroll()
 </script>

--- a/src/lib/hooks/useWindowSize/usage.txt
+++ b/src/lib/hooks/useWindowSize/usage.txt
@@ -1,5 +1,5 @@
 <script>
-import { useWindowSize } from 'svelte-use';
+import { useWindowSize } from 'svelte-legos';
 
 const size = useWindowSize()
 </script>


### PR DESCRIPTION
Hi, I saw that some of the imports were still using `$lib` paths, so I've updated them to use the package name instead.
I also added the github infos to `package.json` so they appear on the npm site. Hope that's okay.