### PR TITLE
fix(Website): Svelte Legos getting horizontal scroll

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,7 +14,7 @@ import { SiteDescription, SiteName, SiteTitle } from "./constants";
 
 <div class="bg-gray-50">
 	<Header />
-	<main class="pt-16 w-screen min-h-[100vh]">
+	<main class="pt-16 w-full min-h-[100vh]">
 		<div class="container mx-auto">
 			<slot />
 		</div>


### PR DESCRIPTION
 This is because of tailwind "w-screen" updated it to "w-full"