### PR TITLE
fix: ts error for actions with custom events

### DIFF
--- a/src/lib/actions/clickOutsideAction/demo.svelte
+++ b/src/lib/actions/clickOutsideAction/demo.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 import { clickOutsideAction } from "$lib";
 import DemoContainer from "$lib/shared/components/DemoContainer.svelte";
 import PrimaryButton from "$lib/shared/components/PrimaryButton.svelte";

--- a/src/lib/actions/clickOutsideAction/index.ts
+++ b/src/lib/actions/clickOutsideAction/index.ts
@@ -1,7 +1,12 @@
 import { listen } from "svelte/internal";
+import type { ActionReturn } from "svelte/action";
 
-export function clickOutsideAction<T extends Element>(node: T) {
-	const handleClick = (event: MouseEvent) => {
+interface Attributes {
+	"on:clickoutside": (e: CustomEvent<void>) => void;
+}
+
+export function clickOutsideAction(node: HTMLElement): ActionReturn<{}, Attributes> {
+	const handleClick = (event: Event) => {
 		if (event.target !== null && !node.contains(event.target as Node)) {
 			node.dispatchEvent(new CustomEvent("clickoutside"));
 		}


### PR DESCRIPTION
I corrected the way in which the action that emits an event is recorded. Specifically, the action was reporting a TypeScript error for the non-existent event.
I based myself on the specifications of this link:
https://github.com/sveltejs/language-tools/blob/master/docs/preprocessors/typescript.md#im-using-an-attributeevent-on-a-dom-element-and-it-throws-a-type-error

Before:
![image](https://user-images.githubusercontent.com/47756116/235239322-e1ece1ca-404f-4ff1-924e-c59cdac2f74c.png)
After:
![image](https://user-images.githubusercontent.com/47756116/235239367-6548d3db-905b-434f-bf5a-f20091a2db93.png)
