### PR TITLE
Add author, copyright and license, closes #81

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Ankur Singhal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ This project is heavily inspired by the following awesome projects.
 - [u3u/vue-hooks](https://github.com/u3u/vue-hooks)
 - [logaretm/vue-use-web](https://github.com/logaretm/vue-use-web)
 - [kripod/react-hooks](https://github.com/kripod/react-hooks)
+
+## License
+
+[MIT](LICENSE.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "svelte-legos",
 	"version": "0.2.0",
+	"description": "A framework for Svelte Utilities",
+	"author": "Ankur Singhal",
+	"license": "MIT",
 	"main": "./package/index.js",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
I suggest using MIT, since it's a widely used license for Javascript projects. [mend.io](https://www.mend.io/resources/blog/open-source-licenses-trends-and-predictions/) (from 2022) states that "The Apache 2.0 License Takes The Lead", with MIT as the second most popular license. I still think MIT is the best choice, since it's more familiar (IMO) to many users.

You can see the license description in LICENSE.md in this PR, but here are some things I like about it:

* It allows anyone to use the software in any form they want.
* It requires anyone who copies the project to continue to use the MIT license.
* It states that there is no warranty.

I also added "copyright", "author" and "description". "description" is not strictly related to this issue, but "copyright" and "author" is important to add at the same time.

Reference: #81.