### PR TITLE
feat: allow passing callback to clickOutside

### DIFF
--- a/src/lib/actions/clickOutsideAction/demo.svelte
+++ b/src/lib/actions/clickOutsideAction/demo.svelte
@@ -16,5 +16,11 @@ let showModal = true;
 		>
 			<Text>Click outside me!</Text>
 		</div>
+		<div
+			class="border border-black p-4 w-80 h-40 fixed top-1/2 left-1/2 bg-slate-300 transform -translate-x-1/2 -translate-y-1/2 shadow-2xl rounded-lg"
+			use:clickOutsideAction={() => (showModal = false)}
+		>
+			<Text>Click outside me!</Text>
+		</div>
 	{/if}
 </DemoContainer>

--- a/src/lib/actions/clickOutsideAction/index.ts
+++ b/src/lib/actions/clickOutsideAction/index.ts
@@ -2,13 +2,16 @@ import { listen } from "svelte/internal";
 import type { ActionReturn } from "svelte/action";
 
 interface Attributes {
-	"on:clickoutside": (e: CustomEvent<void>) => void;
+	"on:clickoutside"?: (e: CustomEvent<void>) => void;
 }
 
-export function clickOutsideAction(node: HTMLElement): ActionReturn<{}, Attributes> {
+type Callback = () => unknown
+
+export function clickOutsideAction(node: HTMLElement, callback?: Callback): ActionReturn<{}, Attributes> {
 	const handleClick = (event: Event) => {
 		if (event.target !== null && !node.contains(event.target as Node)) {
 			node.dispatchEvent(new CustomEvent("clickoutside"));
+                        callback?.();
 		}
 	};
 

--- a/src/lib/actions/clickOutsideAction/usage.txt
+++ b/src/lib/actions/clickOutsideAction/usage.txt
@@ -13,3 +13,8 @@ function handleClickOutside() {
   use:clickOutsideAction
   on:clickoutside={handleClickOutside}
 />
+
+<div
+  class="modal"
+  use:clickOutsideAction={handleClickOutside}
+/>


### PR DESCRIPTION
I think it can be more succinct to pass a callback to the action directly, instead of listening to a custom event.

Both approaches are compatible and the developer can choose whichever they prefer.

Feedback regarding any documentation adjustments are welcome!
