### PR TITLE
feat: Portal Action

### DIFF
--- a/src/lib/actions/portalAction/demo.svelte
+++ b/src/lib/actions/portalAction/demo.svelte
@@ -1,0 +1,43 @@
+<script>
+import { portalAction } from "$lib";
+import DemoContainer from "$lib/shared/components/DemoContainer.svelte";
+import { PrimaryButtonClassName } from "$lib/shared/tailwind";
+
+let target = "body";
+let showPortal = false;
+</script>
+
+<div id="container" class="relative">
+	<DemoContainer>
+		<div class="py-4">
+			<div class="mb-4">
+				<label class="mr-2">
+					<input type="radio" name="type" value="body" bind:group={target} />
+					Portal to body (default)
+				</label>
+				<label class="mr-2">
+					<input type="radio" name="type" value="#container" bind:group={target} />
+					Portal to this container
+				</label>
+			</div>
+			<button class={PrimaryButtonClassName} on:click={() => (showPortal = true)}>
+				Show portal content
+			</button>
+		</div>
+	</DemoContainer>
+</div>
+{#if showPortal}
+	<div
+		use:portalAction={target}
+		class="bg-black bg-opacity-50 inset-0 grid place-content-center p-4"
+		class:fixed={target === "body"}
+		class:absolute={target === "#container"}
+	>
+		<div class="bg-white rounded text-center p-4">
+			<p class="mb-4">This element will render as a direct child of "{target}"</p>
+			<button class={PrimaryButtonClassName} on:click={() => (showPortal = false)}>
+				Close portal content
+			</button>
+		</div>
+	</div>
+{/if}

--- a/src/lib/actions/portalAction/index.ts
+++ b/src/lib/actions/portalAction/index.ts
@@ -1,0 +1,42 @@
+import { tick } from "svelte";
+
+export function portalAction<T extends HTMLElement>(
+	element: T,
+	target: HTMLElement | string = "body"
+) {
+	let targetEl: HTMLElement | null;
+	const update = async (newTarget: HTMLElement | string) => {
+		destroy();
+		element.hidden = true;
+		target = newTarget;
+		if (typeof target === "string") {
+			targetEl = document.querySelector(target);
+			if (targetEl === null) {
+				await tick();
+				targetEl = document.querySelector(target);
+			}
+			if (targetEl === null) {
+				throw new Error(`No element found matching selector: "${target}"`);
+			}
+		} else if (target instanceof HTMLElement) {
+			targetEl = target;
+		} else {
+			const targetType = target === null ? "null" : typeof target;
+			throw new TypeError(
+				`Unknown portal target type: ${targetType}. Allowed types: string (CSS selector) or HTMLElement.`
+			);
+		}
+		targetEl.appendChild(element);
+		element.hidden = false;
+	};
+	const destroy = () => {
+		if (element.parentNode) {
+			element.parentNode.removeChild(element);
+		}
+	};
+	update(target);
+	return {
+		update,
+		destroy,
+	};
+}

--- a/src/lib/actions/portalAction/meta.json
+++ b/src/lib/actions/portalAction/meta.json
@@ -1,0 +1,3 @@
+{
+	"description": "An action that lets your components render some of their children into a different place in the DOM."
+}

--- a/src/lib/actions/portalAction/usage.txt
+++ b/src/lib/actions/portalAction/usage.txt
@@ -1,0 +1,10 @@
+<script>
+  import { portalAction } from "svelte-legos";
+</script>
+
+// This action takes only one optional parameter: a target
+// The target can be a CSS selector or an HTML element
+// The default target is "body"
+<div use:portalAction={"body"}>
+  This element will render as a direct child of the document's body
+</div>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -47,6 +47,7 @@ export { confettiAction } from "./actions/confettiAction";
 export { focusAction } from "./actions/focusAction";
 export { scrollToBottomAction } from "./actions/scrollToBottomAction";
 export { infiniteScrollAction } from "./actions/infiniteScrollAction";
+export { portalAction } from "./actions/portalAction";
 export { scrollToElementAction } from "./__bin__/scrollToElementAction";
 
 export { fetchWithTimeoutAndRetry } from "./utilities/fetchWithTimeoutAndRetry";


### PR DESCRIPTION
I think having a portal action would be a nice addition. This action works the same as React's `createPortal` function, letting you render any element into a different part of the DOM.

For reference, I based this off the [svelte-portal ](https://github.com/romkor/svelte-portal) library, which seems abandoned.