### PR TITLE
svelte 5 compatibility: storage middleware

### DIFF
--- a/src/lib/shared/index.ts
+++ b/src/lib/shared/index.ts
@@ -1,10 +1,21 @@
-import { get_current_component, onDestroy } from "svelte/internal";
+import { onDestroy } from "svelte";
 import { get, type Readable, type Writable } from "svelte/store";
-import { is_client } from "svelte/internal";
+
+// Import get_current_component, but make it optional
+let get_current_component: (() => any) | undefined;
+try {
+	// This will work in Svelte 4 but fail in Svelte 5
+	get_current_component = require('svelte/internal').get_current_component;
+} catch {
+	// In Svelte 5, this import will fail, so we set it to undefined
+}
 
 export function tryOnDestroy(fn: () => void) {
 	try {
-		get_current_component();
+		// If get_current_component is available (Svelte 4), use it
+		if (get_current_component) {
+			get_current_component();
+		}
 		onDestroy(fn);
 	} catch {
 		// fail silently
@@ -43,6 +54,7 @@ export function isSafeIntegerThrowable(int: unknown) {
 	}
 }
 
-export const isClient = is_client;
-export const defaultWindow = is_client ? window : undefined;
-export const defaultDocument = is_client ? window.document : undefined;
+// Define isClient without relying on svelte/internal
+export const isClient = typeof window !== 'undefined';
+export const defaultWindow = isClient ? window : undefined;
+export const defaultDocument = isClient ? window.document : undefined;


### PR DESCRIPTION
Replaced svelte/internal dependencies in src/lib/shared/index.ts to ensure Svelte 5 compatibility for the storage middleware.
Other utilities still depend on svelte/internal and require further updates.

Changes made:
- Replaced `is_client` with `typeof window !== 'undefined';`
- Add try-catch for `get_current_component` import