### PR TITLE
Fix windowSizeStore

### DIFF
--- a/src/lib/stores/windowSizeStore/index.ts
+++ b/src/lib/stores/windowSizeStore/index.ts
@@ -24,14 +24,17 @@ export function windowSizeStore({ window = defaultWindow }: ConfigurableWindow =
 			set(getCurrentWindowDimenstions());
 		}
 
-		if(window) {
+		let cleanup = Function.prototype;
+
+		if (window) {
 			window.addEventListener("resize", handler);
+			cleanup = () => {
+				window.removeEventListener("resize", handler);
+			}
 		}
 		
 		return () => {
-			if (window) {
-				window.removeEventListener("resize", handler);
-			}
+			cleanup();
 		};
 	});
 

--- a/src/lib/stores/windowSizeStore/index.ts
+++ b/src/lib/stores/windowSizeStore/index.ts
@@ -29,7 +29,9 @@ export function windowSizeStore({ window = defaultWindow }: ConfigurableWindow =
 		}
 		
 		return () => {
-			window.removeEventListener("resize", handler);
+			if (window) {
+				window.removeEventListener("resize", handler);
+			}
 		};
 	});
 


### PR DESCRIPTION
It's very likely my last PR is the reason this was broken in the first place, my apologies. 

This fixes an error which causes the docs site to not run due to an SSR error involving `window` being undefined. 